### PR TITLE
[ci skip] Update README, AWS_REGION is a must

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Or install it yourself as:
 ```sh
 export AWS_ACCESS_KEY_ID='...'
 export AWS_SECRET_ACCESS_KEY='...'
+export AWS_REGION='...'
 roadwork -e -o Routefile
 vi Routefile
 roadwork -a --dry-run


### PR DESCRIPTION
aws-sdk-ruby requires `AWS_REGION`.

> You need to configure :credentials and a :region to make API calls. 
> https://github.com/aws/aws-sdk-ruby/blob/f807dd4d938facf08de2ab452f2eeaee2fea7d39/README.md#configuration

Without it, an exception will be thrown like this:

```
$ bundle exec roadwork --apply --dry-run
[ERROR] Aws::Errors::MissingRegionError: missing region; use :region option or export region name to ENV['AWS_REGION']
```
